### PR TITLE
Feature/password find 비밀번호 재설정 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
             'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
 
     implementation 'com.querydsl:querydsl-jpa:4.4.0'
 
@@ -63,7 +64,7 @@ test {
 
 asciidoctor {
     dependsOn test
-    attributes 'snippets':snippetsDir
+    attributes 'snippets': snippetsDir
     inputs.dir snippetsDir
 }
 
@@ -92,8 +93,9 @@ compileQuerydsl {
     options.annotationProcessorPath = configurations.querydsl
 }
 tasks.withType(JavaCompile) {
-    options.generatedSourceOutputDirectory = file(querydslDir) }
-compileQuerydsl.doFirst { if(file(querydslDir).exists() ) delete(file(querydslDir)) }
+    options.generatedSourceOutputDirectory = file(querydslDir)
+}
+compileQuerydsl.doFirst { if (file(querydslDir).exists()) delete(file(querydslDir)) }
 compileQuerydsl.doLast {
     file(querydslDir).delete()
 }

--- a/src/main/java/com/example/bobfriend/configuration/SecurityConfig.java
+++ b/src/main/java/com/example/bobfriend/configuration/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         "/api/validate/**/",
                         "/api/",
                         "/api/issue",
-                        "/api/user/reset",
+                        "/api/user/password",
                         "/docs/api-doc.html").permitAll()
                 .anyRequest().hasRole("USER")
 

--- a/src/main/java/com/example/bobfriend/configuration/SecurityConfig.java
+++ b/src/main/java/com/example/bobfriend/configuration/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         "/api/validate/**/",
                         "/api/",
                         "/api/issue",
+                        "/api/user/reset",
                         "/docs/api-doc.html").permitAll()
                 .anyRequest().hasRole("USER")
 

--- a/src/main/java/com/example/bobfriend/controller/MemberController.java
+++ b/src/main/java/com/example/bobfriend/controller/MemberController.java
@@ -73,7 +73,8 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @PutMapping("/user/reset")
+
+    @PutMapping("/user/password")
     public ResponseEntity resetPassword(@RequestBody ResetPassword resetPassword) {
         String newPassword = memberService.resetPassword(resetPassword);
         emailService.sendMail(resetPassword.getEmail(), "밥친구함 password 관련 메일", newPassword);

--- a/src/main/java/com/example/bobfriend/controller/MemberController.java
+++ b/src/main/java/com/example/bobfriend/controller/MemberController.java
@@ -1,9 +1,10 @@
 package com.example.bobfriend.controller;
 
 import com.example.bobfriend.model.dto.member.Delete;
+import com.example.bobfriend.model.dto.member.ResetPassword;
 import com.example.bobfriend.model.dto.member.Score;
 import com.example.bobfriend.model.dto.member.Update;
-import com.example.bobfriend.service.AuthService;
+import com.example.bobfriend.service.EmailService;
 import com.example.bobfriend.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,8 @@ import javax.validation.Valid;
 @RequestMapping("/api")
 public class MemberController {
     private final MemberService memberService;
+    private final EmailService emailService;
+
 
     @GetMapping("")
     public ResponseEntity verifyEmail(@RequestParam String email, @RequestParam String code) {
@@ -69,4 +72,12 @@ public class MemberController {
         memberService.rateMember(nickname, scoreDto);
         return ResponseEntity.ok().build();
     }
+
+    @PutMapping("/user/reset")
+    public ResponseEntity resetPassword(@RequestBody ResetPassword resetPassword) {
+        String newPassword = memberService.resetPassword(resetPassword);
+        emailService.sendMail(resetPassword.getEmail(), "밥친구함 password 관련 메일", newPassword);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/example/bobfriend/model/dto/member/ResetPassword.java
+++ b/src/main/java/com/example/bobfriend/model/dto/member/ResetPassword.java
@@ -1,0 +1,13 @@
+package com.example.bobfriend.model.dto.member;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class ResetPassword {
+    private String email;
+    private LocalDate birth;
+}

--- a/src/test/java/com/example/bobfriend/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/bobfriend/controller/MemberControllerTest.java
@@ -8,7 +8,6 @@ import com.example.bobfriend.service.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -16,7 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
@@ -48,8 +47,7 @@ class MemberControllerTest {
     MemberService memberService;
 
     Member testMember;
-    @Mock
-    private PasswordEncoder passwordEncoder;
+
 
     @BeforeEach
     public void setup() {
@@ -223,6 +221,26 @@ class MemberControllerTest {
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("토큰")
                         )));
+    }
+
+
+    @Test
+    void resetPasswordTest() throws Exception {
+        String newPassword = "new-password";
+        when(memberService.resetPassword(any()))
+                .thenReturn(newPassword);
+        ResetPassword resetPassword = new ResetPassword();
+        resetPassword.setEmail(testMember.getEmail());
+        resetPassword.setBirth(testMember.getBirth());
+
+        mvc.perform(put("/api/user/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(resetPassword)))
+                .andExpect(status().isOk())
+                .andDo(document("member/reset-password",
+                        getDocumentRequest(),
+                        getDocumentResponse()));
     }
 
 }

--- a/src/test/java/com/example/bobfriend/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/bobfriend/controller/MemberControllerTest.java
@@ -3,7 +3,7 @@ package com.example.bobfriend.controller;
 import com.example.bobfriend.model.dto.member.*;
 import com.example.bobfriend.model.entity.Member;
 import com.example.bobfriend.model.entity.Sex;
-import com.example.bobfriend.service.AuthService;
+import com.example.bobfriend.service.EmailService;
 import com.example.bobfriend.service.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +43,7 @@ class MemberControllerTest {
     @Autowired
     ObjectMapper objectMapper;
     @MockBean
-    AuthService authService;
+    EmailService emailService;
     @MockBean
     MemberService memberService;
 

--- a/src/test/java/com/example/bobfriend/service/MemberServiceTest.java
+++ b/src/test/java/com/example/bobfriend/service/MemberServiceTest.java
@@ -1,9 +1,6 @@
 package com.example.bobfriend.service;
 
-import com.example.bobfriend.model.dto.member.Delete;
-import com.example.bobfriend.model.dto.member.Response;
-import com.example.bobfriend.model.dto.member.Score;
-import com.example.bobfriend.model.dto.member.Update;
+import com.example.bobfriend.model.dto.member.*;
 import com.example.bobfriend.model.entity.*;
 import com.example.bobfriend.repository.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -174,6 +171,24 @@ public class MemberServiceTest {
         Response updatedMember = memberService.update(incoming);
 
         assertThat(updatedMember.getNickname(), equalTo(incoming.getNickname()));
+    }
+
+
+    @Test
+    void resetPasswordTest() {
+        when(memberRepository.findMemberWithAuthoritiesByEmail(any()))
+                .thenReturn(Optional.ofNullable(testMember));
+        when(passwordEncoder.encode(any()))
+                .thenReturn("new-password");
+        ResetPassword resetPasswordDto = new ResetPassword();
+        resetPasswordDto.setEmail(testMember.getEmail());
+        resetPasswordDto.setBirth(testMember.getBirth());
+
+        String resetPassword = memberService.resetPassword(resetPasswordDto);
+
+        assertThat(testMember.getPassword(), equalTo(
+                passwordEncoder.encode(resetPassword)
+        ));
     }
 
 


### PR DESCRIPTION
비밀번호 재설정은 이메일, 생년월일을 받아 사용자를 확인하고(생년월일은 서비스 내에서 다른 사람에게 공개되지 않음) 랜덤문자열을 반환합니다. 랜덤문자열은 apache.commons.text 라이브러리의 RandomStringFenerator를 사용해서 생성합니다. 생성된 문자열은 암호화되어 멤버에 저장되고, 해당 멤버의 이메일을 통해 안내됩니다. 